### PR TITLE
feat: add support for URI field in content of tiles

### DIFF
--- a/tileset/tileset.go
+++ b/tileset/tileset.go
@@ -38,11 +38,11 @@ type Tile struct {
 }
 
 type Content struct {
-	BoundingVolume BoundingVolume `json:"boundingVolume,omitempty"`
-	// change it to "uri" https://github.com/CesiumGS/3d-tiles/tree/main/specification#content
-	URL        string                  `json:"url"`
-	Extentions *map[string]interface{} `json:"extension,omitempty"`
-	Extras     *interface{}            `json:"extras,omitempty"`
+	BoundingVolume BoundingVolume          `json:"boundingVolume,omitempty"`
+	URL            string                  `json:"url,omitempty"`
+	URI            string                  `json:"uri,omitempty"`
+	Extentions     *map[string]interface{} `json:"extension,omitempty"`
+	Extras         *interface{}            `json:"extras,omitempty"`
 }
 
 type BoundingVolume struct {


### PR DESCRIPTION
This PR fixes the #4 
Tile content can either contain a URL or a URI field.