### PR TITLE
fix: read binary reference entries in batchtable binary

### DIFF
--- a/b3dm/binary_reference.go
+++ b/b3dm/binary_reference.go
@@ -39,6 +39,29 @@ func ContainerTypeSize(tp string) int {
 	}
 }
 
+func ComponentTypeSize(tp string) int {
+	switch tp {
+	case COMPONENT_TYPE_BYTE:
+		return 1
+	case COMPONENT_TYPE_UNSIGNED_BYTE:
+		return 1
+	case COMPONENT_TYPE_SHORT:
+		return 2
+	case COMPONENT_TYPE_UNSIGNED_SHORT:
+		return 2
+	case COMPONENT_TYPE_INT:
+		return 4
+	case COMPONENT_TYPE_UNSIGNED_INT:
+		return 4
+	case COMPONENT_TYPE_FLOAT:
+		return 4
+	case COMPONENT_TYPE_DOUBLE:
+		return 8
+	default:
+		return 0
+	}
+}
+
 type BinaryBodyReference struct {
 	ByteOffset    uint32 `json:"byteOffset"`
 	ComponentType string `json:"componentType,omitempty"`

--- a/b3dm/feature_table.go
+++ b/b3dm/feature_table.go
@@ -18,8 +18,8 @@ type FeatureTable struct {
 }
 
 func (h *FeatureTable) GetBatchLength() int {
-	if h.Data["BATCH_LENGTH"] != nil {
-		switch d := h.Data["BATCH_LENGTH"].(type) {
+	if h.Header["BATCH_LENGTH"] != nil {
+		switch d := h.Header["BATCH_LENGTH"].(type) {
 		case int:
 			return d
 		case float64:


### PR DESCRIPTION
This PR fixes a bug observed while fetching the data inside the `BinaryReferenceBody` type entries on the BatchTable.Data.