### PR TITLE
chore: replace pkg/errors with errors

### DIFF
--- a/b3dm/b3dm.go
+++ b/b3dm/b3dm.go
@@ -2,10 +2,10 @@ package b3dm
 
 import (
 	"encoding/binary"
+	"errors"
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/qmuntal/gltf"
 )
 
@@ -60,7 +60,6 @@ type B3dm struct {
 	Model        *gltf.Document
 }
 
-
 func B3dmFeatureTableDecode(header map[string]interface{}, buff []byte) map[string]interface{} {
 	ret := make(map[string]interface{})
 	l := getIntegerScalarFeatureValue(header, buff, B3DM_PROP_BATCH_LENGTH)
@@ -104,29 +103,29 @@ func NewB3dmReader(r io.Reader) *B3dmReader {
 
 func (r *B3dmReader) DecodeHeader(d *B3dmHeader) error {
 	if err := binary.Read(r.rs, littleEndian, d); err != nil {
-		return errors.Wrap(err, "failed to read header")
+		return errors.New("failed to read header")
 	}
 	return nil
 }
 
 func (r *B3dmReader) Decode(m *B3dm) error {
 	if err := r.DecodeHeader(&m.Header); err != nil {
-		return errors.Wrap(err, "failed to decode header")
+		return errors.New("failed to decode header")
 	}
 
 	m.FeatureTable.decode = B3dmFeatureTableDecode
 
 	if err := m.FeatureTable.Read(r.rs, m.GetHeader()); err != nil {
-		return errors.Wrap(err, "failed to read FeatureTable")
+		return errors.New("failed to read FeatureTable")
 	}
 
 	if err := m.BatchTable.Read(r.rs, m.GetHeader(), m.FeatureTable.GetBatchLength()); err != nil {
-		return errors.Wrap(err, "failed to read BatchTable")
+		return errors.New("failed to read BatchTable")
 	}
 
 	var err1 error
 	if m.Model, err1 = loadGltfFromByte(r.rs); err1 != nil {
-		return errors.Wrap(err1, "failed to load glTF file")
+		return errors.New( "failed to load glTF file")
 	}
 
 	return nil
@@ -136,13 +135,13 @@ func (r *B3dmReader) Decode(m *B3dm) error {
 func Open(fileName string) (*B3dm, error) {
 	f, err := os.Open(fileName)
 	if err != nil {
-		return nil, errors.Wrap(err, "open failed")
+		return nil, errors.New("open failed")
 	}
 	defer f.Close()
 	b3dmReader := NewB3dmReader(f)
 	b3d := new(B3dm)
 	if err := b3dmReader.Decode(b3d); err != nil {
-		return nil, errors.Wrap(err, "failed to decode the b3dm file")
+		return nil, errors.New("failed to decode the b3dm file")
 	}
 	return b3d, nil
 }

--- a/b3dm/b3dm.go
+++ b/b3dm/b3dm.go
@@ -2,9 +2,9 @@ package b3dm
 
 import (
 	"encoding/binary"
-	"errors"
 	"io"
 	"os"
+	"fmt"
 
 	"github.com/qmuntal/gltf"
 )
@@ -103,29 +103,29 @@ func NewB3dmReader(r io.Reader) *B3dmReader {
 
 func (r *B3dmReader) DecodeHeader(d *B3dmHeader) error {
 	if err := binary.Read(r.rs, littleEndian, d); err != nil {
-		return errors.New("failed to read header")
+		return fmt.Errorf("failed to read header: %w", err)
 	}
 	return nil
 }
 
 func (r *B3dmReader) Decode(m *B3dm) error {
 	if err := r.DecodeHeader(&m.Header); err != nil {
-		return errors.New("failed to decode header")
+		return fmt.Errorf("failed to decode header: %w", err)
 	}
 
 	m.FeatureTable.decode = B3dmFeatureTableDecode
 
 	if err := m.FeatureTable.Read(r.rs, m.GetHeader()); err != nil {
-		return errors.New("failed to read FeatureTable")
+		return fmt.Errorf("failed to read FeatureTable: %w", err)
 	}
 
 	if err := m.BatchTable.Read(r.rs, m.GetHeader(), m.FeatureTable.GetBatchLength()); err != nil {
-		return errors.New("failed to read BatchTable")
+		return fmt.Errorf("failed to read BatchTable: %w", err)
 	}
 
 	var err1 error
 	if m.Model, err1 = loadGltfFromByte(r.rs); err1 != nil {
-		return errors.New( "failed to load glTF file")
+		return fmt.Errorf( "failed to load glTF file: %w", err1)
 	}
 
 	return nil
@@ -135,13 +135,13 @@ func (r *B3dmReader) Decode(m *B3dm) error {
 func Open(fileName string) (*B3dm, error) {
 	f, err := os.Open(fileName)
 	if err != nil {
-		return nil, errors.New("open failed")
+		return nil, fmt.Errorf("open failed: %w", err)
 	}
 	defer f.Close()
 	b3dmReader := NewB3dmReader(f)
 	b3d := new(B3dm)
 	if err := b3dmReader.Decode(b3d); err != nil {
-		return nil, errors.New("failed to decode the b3dm file")
+		return nil, fmt.Errorf("failed to decode the b3dm file: %w", err)
 	}
 	return b3d, nil
 }

--- a/b3dm/batch_table.go
+++ b/b3dm/batch_table.go
@@ -3,7 +3,7 @@ package b3dm
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"io"
 )
 
@@ -36,17 +36,17 @@ func (h *BatchTable) Read(reader io.Reader, header Header, batchLength int) erro
 
 	jsonb := make([]byte, jsonLen)
 	if _, err := reader.Read(jsonb); err != nil {
-		return errors.New("failed to read json file")
+		return fmt.Errorf("failed to read json file: %v", err)
 	}
 
 	jsonr := bytes.NewReader(jsonb)
 	if err := h.readJSONHeader(jsonr); err != nil {
-		return errors.New("failed to read jsonHeader file")
+		return fmt.Errorf("failed to read jsonHeader file: %v", err)
 	}
 
 	batchdata := make([]byte, header.GetBatchTableBinaryByteLength())
 	if _, err := reader.Read(batchdata); err != nil {
-		return errors.New("failed to read batchdata")
+		return fmt.Errorf("failed to read batchdata: %v", err)
 	}
 	h.Data = make(map[string]interface{})
 	for k, v := range h.Header {

--- a/b3dm/batch_table.go
+++ b/b3dm/batch_table.go
@@ -3,9 +3,8 @@ package b3dm
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
-
-	"github.com/pkg/errors"
 )
 
 type BatchTable struct {
@@ -37,17 +36,17 @@ func (h *BatchTable) Read(reader io.Reader, header Header, batchLength int) erro
 
 	jsonb := make([]byte, jsonLen)
 	if _, err := reader.Read(jsonb); err != nil {
-		return errors.Wrap(err, "failed to read json file")
+		return errors.New("failed to read json file")
 	}
 
 	jsonr := bytes.NewReader(jsonb)
 	if err := h.readJSONHeader(jsonr); err != nil {
-		return errors.Wrap(err, "failed to read jsonHeader file")
+		return errors.New("failed to read jsonHeader file")
 	}
 
 	batchdata := make([]byte, header.GetBatchTableBinaryByteLength())
 	if _, err := reader.Read(batchdata); err != nil {
-		return errors.Wrap(err, "failed to read batchdata")
+		return errors.New("failed to read batchdata")
 	}
 	h.Data = make(map[string]interface{})
 	for k, v := range h.Header {

--- a/b3dm/feature_table.go
+++ b/b3dm/feature_table.go
@@ -3,7 +3,7 @@ package b3dm
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"io"
 )
 
@@ -37,7 +37,7 @@ func (t *FeatureTable) readJSONHeader(data io.Reader, jsonLength int) error {
 	}
 	t.Header = make(map[string]interface{})
 	if err := dec.Decode(&t.Header); err != nil {
-		return errors.New("failed to decode the json file")
+		return fmt.Errorf("failed to decode the json file: %v", err)
 	}
 	t.Header = transformBinaryBodyReference(t.Header)
 	return nil
@@ -50,7 +50,7 @@ func (h *FeatureTable) readData(reader io.Reader, buffLength int) error {
 	bdata := make([]byte, buffLength)
 	_, err := reader.Read(bdata)
 	if err != nil {
-		return errors.New("failed to read the binary data")
+		return fmt.Errorf("failed to read the binary data: %v", err)
 	}
 	h.Data = h.decode(h.Header, bdata)
 	return nil
@@ -59,11 +59,11 @@ func (h *FeatureTable) readData(reader io.Reader, buffLength int) error {
 func (h *FeatureTable) Read(reader io.Reader, header Header) error {
 	err := h.readJSONHeader(reader, int(header.GetFeatureTableJSONByteLength()))
 	if err != nil {
-		return errors.New("failed to read FeatureTable header")
+		return fmt.Errorf("failed to read FeatureTable header: %v", err)
 	}
 	err = h.readData(reader, int(header.GetFeatureTableBinaryByteLength()))
 	if err != nil {
-		return errors.New("failed to read FeatureTable Data")
+		return fmt.Errorf("failed to read FeatureTable Data: %v", err)
 	}
 	return nil
 }

--- a/b3dm/feature_table.go
+++ b/b3dm/feature_table.go
@@ -3,9 +3,8 @@ package b3dm
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
-
-	"github.com/pkg/errors"
 )
 
 type featureTableDecode func(header map[string]interface{}, buff []byte) map[string]interface{}
@@ -38,7 +37,7 @@ func (t *FeatureTable) readJSONHeader(data io.Reader, jsonLength int) error {
 	}
 	t.Header = make(map[string]interface{})
 	if err := dec.Decode(&t.Header); err != nil {
-		return errors.Wrap(err, "failed to decode the json file")
+		return errors.New("failed to decode the json file")
 	}
 	t.Header = transformBinaryBodyReference(t.Header)
 	return nil
@@ -51,7 +50,7 @@ func (h *FeatureTable) readData(reader io.Reader, buffLength int) error {
 	bdata := make([]byte, buffLength)
 	_, err := reader.Read(bdata)
 	if err != nil {
-		return errors.Wrap(err, "failed to read the binary data")
+		return errors.New("failed to read the binary data")
 	}
 	h.Data = h.decode(h.Header, bdata)
 	return nil
@@ -60,11 +59,11 @@ func (h *FeatureTable) readData(reader io.Reader, buffLength int) error {
 func (h *FeatureTable) Read(reader io.Reader, header Header) error {
 	err := h.readJSONHeader(reader, int(header.GetFeatureTableJSONByteLength()))
 	if err != nil {
-		return errors.Wrap(err, "failed to read FeatureTable header")
+		return errors.New("failed to read FeatureTable header")
 	}
 	err = h.readData(reader, int(header.GetFeatureTableBinaryByteLength()))
 	if err != nil {
-		return errors.Wrap(err, "failed to read FeatureTable Data")
+		return errors.New("failed to read FeatureTable Data")
 	}
 	return nil
 }

--- a/b3dm/gltf.go
+++ b/b3dm/gltf.go
@@ -1,8 +1,8 @@
 package b3dm
 
 import (
+	"fmt"
 	"io"
-	"errors"
 
 	"github.com/qmuntal/gltf"
 )
@@ -11,7 +11,7 @@ func loadGltfFromByte(reader io.Reader) (*gltf.Document, error) {
 	dec := gltf.NewDecoder(reader)
 	doc := new(gltf.Document)
 	if err := dec.Decode(doc); err != nil {
-		return nil, errors.New("failed to decode the glTF doc")
+		return nil, fmt.Errorf("failed to decode the glTF doc: %v", err)
 	}
 	return doc, nil
 }

--- a/b3dm/gltf.go
+++ b/b3dm/gltf.go
@@ -2,8 +2,8 @@ package b3dm
 
 import (
 	"io"
+	"errors"
 
-	"github.com/pkg/errors"
 	"github.com/qmuntal/gltf"
 )
 
@@ -11,7 +11,7 @@ func loadGltfFromByte(reader io.Reader) (*gltf.Document, error) {
 	dec := gltf.NewDecoder(reader)
 	doc := new(gltf.Document)
 	if err := dec.Decode(doc); err != nil {
-		return nil, errors.Wrap(err, "failed to decode the glTF doc")
+		return nil, errors.New("failed to decode the glTF doc")
 	}
 	return doc, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/reearth/go3dtiles
 go 1.19
 
 require (
-	github.com/pkg/errors v0.9.1
 	github.com/qmuntal/gltf v0.23.1
 	github.com/stretchr/testify v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qmuntal/gltf v0.23.1 h1:R8vkbJXmARbD/oI+Yn3252I2qDQ8mljsc88BJJEdYMY=

--- a/tileset/tileset.go
+++ b/tileset/tileset.go
@@ -3,6 +3,7 @@ package tileset
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 )
@@ -89,7 +90,7 @@ func NewTilsetReader(r io.Reader) *TilesetReader {
 
 func (r *TilesetReader) Decode(ts *Tileset) error {
 	if err := json.NewDecoder(r.rs).Decode(&ts); err != nil {
-		return errors.New("failed to decode the JSON tilset data")
+		return fmt.Errorf("failed to decode the JSON tilset data: %v", err)
 	}
 	return nil
 }
@@ -97,7 +98,7 @@ func (r *TilesetReader) Decode(ts *Tileset) error {
 func (ts *Tileset) ToJson() (string, error) {
 	b, err := json.Marshal(ts)
 	if err != nil {
-		return "", errors.New("failed to marshal the tilset JSON")
+		return "", fmt.Errorf("failed to marshal the tilset JSON: %v", err)
 	}
 	return string(b), nil
 }
@@ -105,13 +106,13 @@ func (ts *Tileset) ToJson() (string, error) {
 func Open(fileName string) (*Tileset, error) {
 	f, err := os.Open(fileName)
 	if err != nil {
-		return nil, errors.New("open failed")
+		return nil, fmt.Errorf("open failed: %v", err)
 	}
 	defer f.Close()
 	tilsetReader := NewTilsetReader(f)
 	ts := new(Tileset)
 	if err := tilsetReader.Decode(ts); err != nil {
-		return nil, errors.New("failed to decode the tileset")
+		return nil, fmt.Errorf("failed to decode the tileset: %v", err)
 	}
 	return ts, nil
 }

--- a/tileset/tileset.go
+++ b/tileset/tileset.go
@@ -80,7 +80,7 @@ func (t *Tile) Uri() (string, error) {
 			return "", errors.New("neither URL nor URI exists for this content")
 		}
 	}
-	return "", errors.New("content doerrors not exist")
+	return "", errors.New("content does not exist")
 }
 
 func NewTilsetReader(r io.Reader) *TilesetReader {

--- a/tileset/tileset.go
+++ b/tileset/tileset.go
@@ -2,11 +2,9 @@ package tileset
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
-	es"errors"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -79,10 +77,10 @@ func (t *Tile) Uri() (string, error) {
 		if content.URL != "" {
 			return content.URL, nil
 		} else {
-			return "", es.New("neither URL nor URI exists for this content")
+			return "", errors.New("neither URL nor URI exists for this content")
 		}
 	}
-	return "", es.New("content does not exist")
+	return "", errors.New("content doerrors not exist")
 }
 
 func NewTilsetReader(r io.Reader) *TilesetReader {
@@ -91,26 +89,29 @@ func NewTilsetReader(r io.Reader) *TilesetReader {
 
 func (r *TilesetReader) Decode(ts *Tileset) error {
 	if err := json.NewDecoder(r.rs).Decode(&ts); err != nil {
-		return errors.Wrap(err, "failed to decode the JSON tilset data")
+		return errors.New("failed to decode the JSON tilset data")
 	}
 	return nil
 }
 
 func (ts *Tileset) ToJson() (string, error) {
-	b, e := json.Marshal(ts)
-	return string(b), errors.Wrap(e, "failed to marshal the tilset JSON")
+	b, err := json.Marshal(ts)
+	if err != nil {
+		return "", errors.New("failed to marshal the tilset JSON")
+	}
+	return string(b), nil
 }
 
 func Open(fileName string) (*Tileset, error) {
 	f, err := os.Open(fileName)
 	if err != nil {
-		return nil, errors.Wrap(err, "open failed")
+		return nil, errors.New("open failed")
 	}
 	defer f.Close()
 	tilsetReader := NewTilsetReader(f)
 	ts := new(Tileset)
 	if err := tilsetReader.Decode(ts); err != nil {
-		return nil, errors.Wrap(err, "failed to decode the tileset")
+		return nil, errors.New("failed to decode the tileset")
 	}
 	return ts, nil
 }

--- a/tileset/tileset_test.go
+++ b/tileset/tileset_test.go
@@ -1,11 +1,10 @@
 package tileset
 
 import (
-	"testing"
 	"errors"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
-	// e"github.com/pkg/errors"
 )
 
 const TESTFILE_TILESET = "testdata/tileset.json"


### PR DESCRIPTION
Replacing `pkg/errors` with standard `errors` library for error handling.
While `pkg/errors` provide a better error debugging experience, it doesn't work that well with `testify/assert`
To have fewer external dependencies, we have decided to switch back to the standard library.