### PR TITLE
fix: GetFeatureTableView() wrong type inference fix

### DIFF
--- a/b3dm/b3dm.go
+++ b/b3dm/b3dm.go
@@ -111,7 +111,7 @@ func NewB3dmReader(r io.Reader) *B3dmReader {
 }
 
 func (r *B3dmReader) DecodeHeader(d *B3dmHeader) error {
-	if err := binary.Read(r.rs, _littleEndian, d); err != nil {
+	if err := binary.Read(r.rs, littleEndian, d); err != nil {
 		return errors.Wrap(err, "failed to read header")
 	}
 	return nil

--- a/b3dm/b3dm.go
+++ b/b3dm/b3dm.go
@@ -60,7 +60,6 @@ type B3dm struct {
 	Model        *gltf.Document
 }
 
-
 func B3dmFeatureTableDecode(header map[string]interface{}, buff []byte) map[string]interface{} {
 	ret := make(map[string]interface{})
 	l := getIntegerScalarFeatureValue(header, buff, B3DM_PROP_BATCH_LENGTH)
@@ -73,13 +72,18 @@ func B3dmFeatureTableEncode(header map[string]interface{}, data map[string]inter
 	return nil
 }
 
-func (m *B3dm) GetFeatureTableView() B3dmFeatureTable {
+func (m *B3dm) GetFeatureTableView() *B3dmFeatureTable {
 	ret := B3dmFeatureTable{}
-	ret.BatchLength = m.FeatureTable.Header[B3DM_PROP_BATCH_LENGTH].(int)
+	ret.BatchLength = int(m.FeatureTable.Header[B3DM_PROP_BATCH_LENGTH].(float64))
 	if m.FeatureTable.Header[B3DM_PROP_RTC_CENTER] != nil {
-		ret.RtcCenter = m.FeatureTable.Header[B3DM_PROP_RTC_CENTER].([3]float64)
+		rtcCenterRaw := m.FeatureTable.Header[B3DM_PROP_RTC_CENTER].([]interface{})
+		rtcCenter := [3]float64{}
+		for i := range rtcCenterRaw {
+			rtcCenter[i] = rtcCenterRaw[i].(float64)
+		}
+		ret.RtcCenter = rtcCenter
 	}
-	return ret
+	return &ret
 }
 
 func (m *B3dm) GetHeader() Header {
@@ -107,7 +111,7 @@ func NewB3dmReader(r io.Reader) *B3dmReader {
 }
 
 func (r *B3dmReader) DecodeHeader(d *B3dmHeader) error {
-	if err := binary.Read(r.rs, littleEndian, d); err != nil {
+	if err := binary.Read(r.rs, _littleEndian, d); err != nil {
 		return errors.Wrap(err, "failed to read header")
 	}
 	return nil

--- a/b3dm/b3dm_test.go
+++ b/b3dm/b3dm_test.go
@@ -135,3 +135,33 @@ func TestB3dm_Decode(t *testing.T) {
 		})
 	}
 }
+
+func TestGetFeatureTableView(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    *B3dmFeatureTable
+		wantErr bool
+	}{
+		{"openError", nil, true},
+		{TESTFILE_LL_B3DM, &B3dmFeatureTable{
+			BatchLength: 10,
+			RtcCenter: [3]float64{
+				1.2149145525041146e+06,
+				-4.736388031625768e+06,
+				4.0815480407588882e+06,
+			},
+		}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b3dm, err := Open(tt.name)
+			if !tt.wantErr {
+				if assert.NoError(t, err) {
+					got := b3dm.GetFeatureTableView()
+					assert.Equal(t, got, tt.want, "getFeatureTableView() = false")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PRs fixes the errors observed after the recent changes in the indexer.
I've added the necessary changes and corresponding tests to fix it.